### PR TITLE
feat: move AI transport to headless Node TypeScript backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Conversation shaping for tools:
 
 Key components:
 - lua/neoai/chat.lua — Chat UI, message orchestration, tool invocation, response streaming
+- lua/neoai/api.lua — Lua-side stream orchestration; delegates HTTP transport to Node backend
+- backend/ai_backend.ts — Headless Node.js transport backend for AI API calls/streaming
 - lua/neoai/prompt.lua — Template loading and interpolation for the system prompt
 - lua/neoai/prompts/system_prompt.md — System instructions and placeholders (%tools, %agents)
 - lua/neoai/ai_tools/** — Tool implementations and their descriptions
@@ -48,6 +50,7 @@ Tool output notes:
 ## Dev environment tips
 - Use a local path in your Neovim plugin manager (e.g., lazy.nvim) to load this repository directly during development.
 - Required dependencies: plenary.nvim, telescope.nvim, and optionally nvim-treesitter for TreeSitterQuery; ripgrep (rg) for Grep/ProjectStructure.
+- Node.js 18+ is required for the headless API backend (`backend/ai_backend.ts`); Java is not required.
 - Recommended Neovim: v0.8+.
 - Configure two API profiles in setup: api.main and api.small. The main model is currently used for chat responses.
 - Logging: prefer vim.notify with appropriate severity (DEBUG/INFO/WARN/ERROR) for internal diagnostics; keep noise minimal by default.
@@ -102,7 +105,6 @@ Tool output notes:
 - This file is auto-included into the system prompt at runtime.
 - If you change any of the topics addressed here (overview, commands, code style, testing, security, PR process), update this file as part of the same change.
 - Do not bloat this file; include information that materially improves the agent’s effectiveness working on this repository.
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A powerful AI-enhanced chat interface for Neovim, featuring streaming responses,
 - **Interactive Chat UI**: Split-window chat interface with Markdown rendering and model name display
 - **Session Management**: Telescope-powered session picker for easy navigation
 - **Streaming Responses**: Real-time assistant replies with thinking time indicator and response duration
+- **Headless Node.js Backend**: API calls are proxied through a lightweight Node.js backend script (`backend/ai_backend.ts`)
 - **Advanced Tool System**: Automatic invocation of tools with intelligent feedback loops
   - Project structure analysis
   - File reading and intelligent multi-edit operations
@@ -97,6 +98,9 @@ use {
 
 - ripgrep (rg): required for the Grep and Project Structure tools.
 - nvim-treesitter: For TreeSitterQuery and edit tool; ensure language parsers are installed (e.g., `:TSInstall lua`).
+- Node.js 18+ (recommended 20+): required for the headless AI backend (`fetch` + streaming).
+
+No Java runtime/backend is required.
 
 Note on models:
 

--- a/backend/ai_backend.ts
+++ b/backend/ai_backend.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+/**
+ * Headless AI backend for NeoAI.
+ *
+ * Usage:
+ *   node backend/ai_backend.ts <url> <apiKeyHeader> <apiKeyValue>
+ *
+ * Reads JSON payload from stdin, forwards it to the provider, and mirrors the
+ * provider response to stdout. For SSE streams, raw chunks are forwarded as-is.
+ * For non-stream responses, the body is printed as text.
+ *
+ * Always appends a status trailer line:
+ *   HTTPSTATUS:<code>
+ */
+
+const [,, url, apiKeyHeader, apiKeyValue] = process.argv;
+
+if (!url) {
+  process.stderr.write("Missing URL argument\n");
+  process.exit(2);
+}
+
+const stdinChunks = [];
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => stdinChunks.push(chunk));
+process.stdin.on("error", (err) => {
+  process.stderr.write(`stdin error: ${String(err)}\n`);
+  process.exit(1);
+});
+
+process.stdin.on("end", async () => {
+  const payload = stdinChunks.join("");
+
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  if (apiKeyHeader && apiKeyValue) {
+    headers[apiKeyHeader] = apiKeyValue;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: payload,
+      redirect: "follow",
+    });
+
+    const contentType = (response.headers.get("content-type") || "").toLowerCase();
+    const isSse = contentType.includes("text/event-stream");
+
+    if (isSse && response.body) {
+      const decoder = new TextDecoder("utf-8");
+      const reader = response.body.getReader();
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (value) {
+          process.stdout.write(decoder.decode(value, { stream: true }));
+        }
+      }
+
+      process.stdout.write(decoder.decode());
+      process.stdout.write(`\nHTTPSTATUS:${response.status}\n`);
+      return;
+    }
+
+    const bodyText = await response.text();
+    if (bodyText) {
+      process.stdout.write(bodyText);
+      if (!bodyText.endsWith("\n")) {
+        process.stdout.write("\n");
+      }
+    }
+    process.stdout.write(`HTTPSTATUS:${response.status}\n`);
+  } catch (err) {
+    process.stderr.write(`request error: ${String(err)}\n`);
+    process.exit(1);
+  }
+});
+
+process.stdin.resume();

--- a/lua/neoai/api.lua
+++ b/lua/neoai/api.lua
@@ -3,6 +3,20 @@ local conf = require("neoai.config").get_api("main")
 local tool_schemas = require("neoai.ai_tools").tool_schemas
 local api = {}
 
+---Resolve the repository root from this module path.
+---@return string
+local function repo_root()
+  local src = debug.getinfo(1, "S").source
+  local file = src:sub(1, 1) == "@" and src:sub(2) or src
+  return vim.fn.fnamemodify(file, ":h:h:h")
+end
+
+---Resolve the node backend script path.
+---@return string
+local function backend_script_path()
+  return repo_root() .. "/backend/ai_backend.ts"
+end
+
 -- Track current streaming job
 --- @type Job|nil  -- Current streaming job
 local current_job = nil
@@ -33,7 +47,7 @@ function api.stream(messages, on_chunk, on_complete, on_error, on_cancel)
   local error_reported = false
   -- Buffer non-SSE stdout to recover JSON error bodies when the server doesn't stream
   local non_sse_buf = {}
-  local http_status -- captured from curl --write-out
+  local http_status -- captured from backend status trailer
   -- Create a new job and mark it as not cancelled
 
   local basic_payload = {
@@ -46,9 +60,13 @@ function api.stream(messages, on_chunk, on_complete, on_error, on_cancel)
 
   local payload = vim.fn.json_encode(merge_tables(basic_payload, conf.additional_kwargs or {}))
 
-  -- Optional debug: show the exact JSON payload being sent to curl
+  -- Optional debug: show the exact JSON payload being sent to the Node backend
   if conf.debug_payload then
-    vim.notify("NeoAI: Sending JSON payload to curl (stream):\n" .. payload, vim.log.levels.DEBUG, { title = "NeoAI" })
+    vim.notify(
+      "NeoAI: Sending JSON payload to Node backend (stream):\n" .. payload,
+      vim.log.levels.DEBUG,
+      { title = "NeoAI" }
+    )
   end
 
   -- Accumulate raw body for verbose error reporting in non-SSE cases
@@ -57,27 +75,17 @@ function api.stream(messages, on_chunk, on_complete, on_error, on_cancel)
   local api_key_header = conf.api_key_header or "Authorization"
   local api_key_format = conf.api_key_format or "Bearer %s"
   local api_key_value = string.format(api_key_format, conf.api_key)
-  local api_key = api_key_header .. ": " .. api_key_value
+  local backend_script = backend_script_path()
 
   current_job = Job:new({
-    command = "curl",
+    command = "node",
     args = {
-      "--silent",
-      "--show-error", -- ensure errors are printed even in silent mode
-      "--no-buffer",
-      "--location",
+      backend_script,
       conf.url,
-      "--header",
-      "Content-Type: application/json",
-      "--header",
-      api_key,
-      "--data-binary",
-      "@-",
-      -- Always emit the HTTP status code at the end so we can report it if no JSON error was parsed
-      "--write-out",
-      "\nHTTPSTATUS:%{http_code}\n",
+      api_key_header,
+      api_key_value,
     },
-    -- Send JSON payload via stdin to avoid hitting argv length limits
+    -- Send JSON payload via stdin to avoid hitting argv length limits.
     writer = payload,
     on_stdout = function(_, line)
       for _, data_line in ipairs(vim.split(line, "\n")) do
@@ -191,7 +199,7 @@ function api.stream(messages, on_chunk, on_complete, on_error, on_cancel)
         else
           -- Non-SSE output: capture HTTP status and buffer any JSON body to surface real error messages
           local trimmed = vim.trim(data_line)
-          -- Capture the emitted HTTP status code from curl
+          -- Capture the emitted HTTP status code from the backend trailer
           local st = trimmed:match("^HTTPSTATUS:(%d+)$")
           if st then
             http_status = tonumber(st)
@@ -243,11 +251,10 @@ function api.stream(messages, on_chunk, on_complete, on_error, on_cancel)
       if not line or line == "" then
         return
       end
-      -- With --show-error, curl writes human-readable errors here. Surface immediately for network/transport errors.
       if not error_reported then
         error_reported = true
         vim.schedule(function()
-          local verbose = "curl error: " .. tostring(line)
+          local verbose = "Node backend error: " .. tostring(line)
           vim.notify(verbose, vim.log.levels.ERROR, { title = "NeoAI" })
           on_error(verbose)
         end)
@@ -263,9 +270,9 @@ function api.stream(messages, on_chunk, on_complete, on_error, on_cancel)
               on_cancel()
             end
           else
-            -- If curl failed at the transport level
+            -- If the process failed at the transport/backend level
             if exit_code ~= 0 then
-              local verbose = "curl exited with code: " .. tostring(exit_code)
+              local verbose = "Node backend exited with code: " .. tostring(exit_code)
               vim.notify(verbose, vim.log.levels.ERROR, { title = "NeoAI" })
               on_error(verbose)
             else
@@ -302,7 +309,7 @@ function api.cancel()
   -- Mark this specific job as cancelled
   job._neoai_cancelled = true
 
-  -- For curl SSE, closing pipes (shutdown) is not sufficient; send a signal.
+  -- For streamed requests, closing pipes (shutdown) is not sufficient; send a signal.
   -- Try SIGTERM first; if it doesn't exit quickly, escalate to SIGKILL.
   if type(job.kill) == "function" then
     pcall(function()


### PR DESCRIPTION
### Motivation
- Replace direct `curl` HTTP transport from Lua with a headless Node.js process to centralise HTTP/SSE handling and use `fetch` for streaming support.
- Remove dependency on a Java backend/runtime by making the Node backend the supported headless transport.

### Description
- Add `backend/ai_backend.ts`, a lightweight Node.js TypeScript script that reads JSON from stdin, forwards it to the configured AI endpoint via `fetch`, proxies SSE chunks unchanged, and appends a `HTTPSTATUS:<code>` trailer.
- Update `lua/neoai/api.lua` to resolve and spawn the Node backend (`node backend/ai_backend.ts`) and pass `conf.url`, the API key header and value via argv, while preserving existing SSE/tool-call parsing and status handling in Lua.
- Replace curl-specific error/status messages with Node backend equivalents and adjust comments to reflect backend trailer parsing.
- Update `README.md` and `AGENTS.md` to document the new Node.js 18+ requirement and explicitly note that a Java backend/runtime is not required.

### Testing
- Ran `node --check backend/ai_backend.ts`, which succeeded.
- Attempted Lua syntax/load checks (`luac -p` / `lua -e 'assert(loadfile(...))'`) but they could not be executed in this environment because `luac`/`lua` binaries are not installed (no result).
- Committed changes and verified files were added/updated (`backend/ai_backend.ts`, `lua/neoai/api.lua`, `README.md`, `AGENTS.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59f569e7483228ece032c4460d9d6)